### PR TITLE
Prevent developer tests running by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ perl:
 before_install:
     - "sudo apt-get update"
     - "sudo apt-get install libxml2-dev"
+env:
+    - RELEASE_TESTING=1

--- a/t/11memory.t
+++ b/t/11memory.t
@@ -5,6 +5,9 @@ use lib './t/lib';
 use TestHelpers qw(slurp);
 
 use Test::More;
+
+plan skip_all => "These tests are for authors only!" unless $ENV{AUTHOR_TESTING} or $ENV{RELEASE_TESTING};
+
 use constant TIMES_THROUGH => $ENV{MEMORY_TIMES} || 100_000;
 
 if (! (($^O eq 'linux') || ($^O eq 'cygwin')) )
@@ -257,7 +260,7 @@ dromeds.xml
 
 #        {
 #            print "# ENCODING TESTS \n";
-#            my $string = "test ä ø is a test string to test iso encoding";
+#            my $string = "test ï¿½ ï¿½ is a test string to test iso encoding";
 #            my $encstr = encodeToUTF8( "iso-8859-1" , $string );
 #            for ( 1..TIMES_THROUGH ) {
 #                my $str = encodeToUTF8( "iso-8859-1" , $string );

--- a/t/cpan-changes.t
+++ b/t/cpan-changes.t
@@ -5,8 +5,9 @@ use warnings;
 
 use Test::More;
 
+plan skip_all => "These tests are for authors only!" unless $ENV{AUTHOR_TESTING} or $ENV{RELEASE_TESTING};
+
 eval 'use Test::CPAN::Changes 0.27';
 plan skip_all => 'Test::CPAN::Changes 0.27 required for this test' if $@;
 
 changes_ok();
-

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,6 +1,9 @@
 #!perl -T
 
 use Test::More;
+
+plan skip_all => "These tests are for authors only!" unless $ENV{AUTHOR_TESTING} or $ENV{RELEASE_TESTING};
+
 eval "use Test::Pod 1.14";
 plan skip_all => "Test::Pod 1.14 required for testing POD" if $@;
 all_pod_files_ok();

--- a/t/release-kwalitee.t
+++ b/t/release-kwalitee.t
@@ -4,6 +4,8 @@ use strict;
 use warnings;
 use Test::More;   # needed to provide plan.
 
+plan skip_all => "These tests are for authors only!" unless $ENV{AUTHOR_TESTING} or $ENV{RELEASE_TESTING};
+
 eval { require Test::Kwalitee::Extra };
 plan skip_all => "Test::Kwalitee::Extra required for testing kwalitee: $@" if $@;
 

--- a/t/style-trailing-space.t
+++ b/t/style-trailing-space.t
@@ -5,6 +5,8 @@ use warnings;
 
 use Test::More;
 
+plan skip_all => "These tests are for authors only!" unless $ENV{AUTHOR_TESTING} or $ENV{RELEASE_TESTING};
+
 eval "use Test::TrailingSpace";
 if ($@)
 {


### PR DESCRIPTION
This commit addresses the messages in RT in regard to "Please don't
allow pod, critic or kwalitee tests to run for normal user installs"

So apply the same code as in 11memory.t on t/pod.t, t/release-kwalitee.t
and t/style-trailing-space.t

This commit answers the (automated) messages on a variety of RT tickets suggesting this change. Not sure if it is a change you'd like in the codebase. Let me know what changes you'd like if you are ok with this change going into the repo.

This is triggered by CPAN Pull Request Challenge.