### PR TITLE
fix for cperl strict hashpairs

### DIFF
--- a/LibXML.pm
+++ b/LibXML.pm
@@ -763,7 +763,8 @@ sub __write {
 
 sub load_xml {
   my $class_or_self = shift;
-  my %args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+  my @args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+  my %args = @args;
 
   my $URI = delete($args{URI});
   $URI = "$URI"  if defined $URI; # stringify in case it is an URI object
@@ -792,7 +793,8 @@ sub load_xml {
 
 sub load_html {
   my ($class_or_self) = shift;
-  my %args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+  my @args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+  my %args = @args;
   my $URI = delete($args{URI});
   $URI = "$URI"  if defined $URI; # stringify in case it is an URI object
   my $parser;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -191,6 +191,7 @@ unless ( $is_Win32 ) { # cannot get config in W32
                      [2,9,3,1], # schema regression
                      [2,9,4,0], # schema regression
                      [2,9,6,1],
+                     [2,9,7,1], # tested, ok
                     );
     my $xml2cfg = "xml2-config";
     my $libprefix = $ENV{XMLPREFIX} || $config{XMLPREFIX};
@@ -300,6 +301,7 @@ GDOME
         }
     }
 }
+
 # -------------------------------------------------------------------------- #
 
 

--- a/lib/XML/LibXML/Reader.pm
+++ b/lib/XML/LibXML/Reader.pm
@@ -116,7 +116,8 @@ our %_preserve_flag;
   }
   sub setParserProp {
     my $self = shift;
-    my %args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+    my @args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+    my %args = @args;
     my ($key, $value);
     while (($key,$value) = each %args) {
       my $prop = $props{ $key };
@@ -128,7 +129,8 @@ our %_preserve_flag;
   my (%string_pool,%rng_pool,%xsd_pool); # used to preserve data passed to the reader
   sub new {
     my ($class) = shift;
-    my %args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+    my @args = map { ref($_) eq 'HASH' ? (%$_) : $_ } @_;
+    my %args = @args;
     my $encoding = $args{encoding};
     my $URI = $args{URI};
     $URI="$URI" if defined $URI; # stringify in case it is an URI object


### PR DESCRIPTION
fatal under use strict since v5.27.0c.
    See https://github.com/perl11/cperl/issues/281
    and http://perl11.org/blog/strict-hashpairs.html

    With map only a missing or a single pair is allowed to construct a hash, not
    multiple pairs.