### PR TITLE
Allow LibParser to be provided for all method

### DIFF
--- a/lib/XML/LibXML/SAX.pm
+++ b/lib/XML/LibXML/SAX.pm
@@ -49,8 +49,7 @@ sub _parse_characterstream {
 
 sub _parse_bytestream {
     my ( $self, $fh ) = @_;
-
-    $self->{ParserOptions}{LibParser}      = XML::LibXML->new;
+    $self->{ParserOptions}{LibParser}      = XML::LibXML->new()     unless defined $self->{ParserOptions}{LibParser};
     $self->{ParserOptions}{ParseFunc}      = \&XML::LibXML::parse_fh;
     $self->{ParserOptions}{ParseFuncParam} = $fh;
     $self->_parse;
@@ -59,7 +58,6 @@ sub _parse_bytestream {
 
 sub _parse_string {
     my ( $self, $string ) = @_;
-#    $self->{ParserOptions}{LibParser}      = XML::LibXML->new;
     $self->{ParserOptions}{LibParser}      = XML::LibXML->new()     unless defined $self->{ParserOptions}{LibParser};
     $self->{ParserOptions}{ParseFunc}      = \&XML::LibXML::parse_string;
     $self->{ParserOptions}{ParseFuncParam} = $string;
@@ -69,7 +67,7 @@ sub _parse_string {
 
 sub _parse_systemid {
     my $self = shift;
-    $self->{ParserOptions}{LibParser}      = XML::LibXML->new;
+    $self->{ParserOptions}{LibParser}      = XML::LibXML->new()     unless defined $self->{ParserOptions}{LibParser};
     $self->{ParserOptions}{ParseFunc}      = \&XML::LibXML::parse_file;
     $self->{ParserOptions}{ParseFuncParam} = shift;
     $self->_parse;
@@ -78,7 +76,7 @@ sub _parse_systemid {
 
 sub parse_chunk {
     my ( $self, $chunk ) = @_;
-    $self->{ParserOptions}{LibParser}      = XML::LibXML->new;
+    $self->{ParserOptions}{LibParser}      = XML::LibXML->new()     unless defined $self->{ParserOptions}{LibParser};
     $self->{ParserOptions}{ParseFunc}      = \&XML::LibXML::parse_xml_chunk;
     $self->{ParserOptions}{LibParser}->{IS_FILTER}=1; # a hack to prevent parse_xml_chunk from issuing end_document
     $self->{ParserOptions}{ParseFuncParam} = $chunk;


### PR DESCRIPTION
Just a report of what _parse_string already did. This don't change anything for everyday use, but it allow XXE mitigation easily when used with XML::Simple.