### PR TITLE
Don't escape pod in synopses.

### DIFF
--- a/example/xmllibxmldocs.pl
+++ b/example/xmllibxmldocs.pl
@@ -474,7 +474,6 @@ sub dump_pod {
         elsif(  $node->nodeName() eq "funcsynopsisinfo" ) {
             my $str = $node->string_value() ;
             $str =~ s/\n/\n  /g;
-            $str = pod_escape($str);
             $self->{OFILE}->print( "  $str\n" );
         } elsif(  $node->nodeName() eq "title" or
                   $node->nodeName() eq "titleabbrev"


### PR DESCRIPTION
Sorry about. I got over-zealous with my pod escapes. No need to escape stuff in synopses.