### PR TITLE
Avoid XXE attacks by default (expand_entities and load_ext_dtd should default to false)

### DIFF
--- a/LibXML.pm
+++ b/LibXML.pm
@@ -261,7 +261,7 @@ use constant {
   HTML_PARSE_NOERROR  => (1<<5),       # suppress error reports
 };
 
-$XML_LIBXML_PARSE_DEFAULTS = ( XML_PARSE_NODICT | XML_PARSE_DTDLOAD | XML_PARSE_NOENT );
+$XML_LIBXML_PARSE_DEFAULTS = ( XML_PARSE_NODICT );
 
 # this hash is made global so that applications can add names for new
 # libxml2 parser flags as temporary workaround
@@ -366,6 +366,7 @@ sub new {
       }
       # parser flags
       $opts{no_blanks} = !$opts{keep_blanks} if exists($opts{keep_blanks}) and !exists($opts{no_blanks});
+      $opts{load_ext_dtd} = $opts{expand_entities} if exists($opts{expand_entities}) and !exists($opts{load_ext_dtd});
 
       for (keys %OUR_FLAGS) {
 	$self->{$OUR_FLAGS{$_}} = delete $opts{$_};

--- a/t/02parse.t
+++ b/t/02parse.t
@@ -720,7 +720,7 @@ my $badXInclude = q{
     my %badstrings = (
                     SIMPLE => '<?xml version="1.0"?>'."\n<A/>\n",
                   );
-    my $parser = XML::LibXML->new;
+    my $parser = XML::LibXML->new(expand_entities => 1);
 
     $parser->validation(1);
     my $doc;
@@ -745,7 +745,7 @@ EOXML
 <bar/>
 EOXML
 
-    my $parser = XML::LibXML->new;
+    my $parser = XML::LibXML->new(expand_entities => 1);
     $parser->validation(1);
 
     eval { $parser->parse_string( $badxml ); };

--- a/t/13dtd.t
+++ b/t/13dtd.t
@@ -69,7 +69,7 @@ ok($dtdstr, "DTD String read");
     # TEST
     ok ($@, '->validate throws an exception');
 
-    my $parser = XML::LibXML->new();
+    my $parser = XML::LibXML->new(load_ext_dtd => 1);
     # TEST
     ok ($parser->validation(1), '->validation returns 1');
     # this one is OK as it's well formed (no DTD)

--- a/t/17callbacks.t
+++ b/t/17callbacks.t
@@ -276,7 +276,7 @@ $XML::LibXML::close_cb = $close1_global_counter->cb();
 
 {
     # tests if global callbacks are working
-    my $parser = XML::LibXML->new();
+    my $parser = XML::LibXML->new(load_ext_dtd => 1);
     # TEST
     ok($parser, '$parser was init');
 

--- a/t/43options.t
+++ b/t/43options.t
@@ -50,7 +50,7 @@ no_network
 {
   my $p = XML::LibXML->new();
   for my $opt (@all) {
-    my $ret = (($opt =~ /^(?:load_ext_dtd|expand_entities)$/) ? 1 : 0);
+    my $ret = 0;
     # TEST*$all
     ok(
         ($p->get_option($opt)||0) == $ret
@@ -110,20 +110,21 @@ no_network
   ok( $p->get_option('recover') == 2, ' TODO : Add test name' );
 
   # TEST
-  ok( $p->expand_entities() == 1, 'expand_entities should default to true' );
+  ok( $p->expand_entities() == 0, 'expand_entities should default to false' );
   # TEST
-  ok( $p->load_ext_dtd() == 1, 'load_ext_dtd should default to true' );
+  ok( $p->load_ext_dtd() == 0, 'load_ext_dtd should default to false' );
+  $p->load_ext_dtd(1);
+  # TEST
+  ok( $p->load_ext_dtd() == 1, 'load_ext_dtd should be true after being set to true' );
   $p->load_ext_dtd(0);
-  # TEST
-  ok( $p->load_ext_dtd() == 0, 'load_ext_dtd should be false after being set to false' );
-  $p->expand_entities(0);
-  # TEST
-  ok( $p->expand_entities() == 0, 'expand_entities should be false after being set to false' );
   $p->expand_entities(1);
   # TEST
   ok( $p->expand_entities() == 1, 'expand_entities should be true after being set to true' );
   # TEST
   ok( $p->load_ext_dtd() == 1, 'load_ext_dtd should be true after expand_entities is set to true' );
+  $p->expand_entities(0);
+  # TEST
+  ok( $p->expand_entities() == 0, 'expand_entities should be false after being set to false' );
 }
 
 {

--- a/t/43options.t
+++ b/t/43options.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 290;
+use Test::More tests => 291;
 
 use XML::LibXML;
 
@@ -110,18 +110,20 @@ no_network
   ok( $p->get_option('recover') == 2, ' TODO : Add test name' );
 
   # TEST
-  ok( $p->expand_entities() == 1, ' TODO : Add test name' );
+  ok( $p->expand_entities() == 1, 'expand_entities should default to true' );
   # TEST
-  ok( $p->load_ext_dtd() == 1, ' TODO : Add test name' );
+  ok( $p->load_ext_dtd() == 1, 'load_ext_dtd should default to true' );
   $p->load_ext_dtd(0);
   # TEST
-  ok( $p->load_ext_dtd() == 0, ' TODO : Add test name' );
+  ok( $p->load_ext_dtd() == 0, 'load_ext_dtd should be false after being set to false' );
   $p->expand_entities(0);
   # TEST
-  ok( $p->expand_entities() == 0, ' TODO : Add test name' );
+  ok( $p->expand_entities() == 0, 'expand_entities should be false after being set to false' );
   $p->expand_entities(1);
   # TEST
-  ok( $p->expand_entities() == 1, ' TODO : Add test name' );
+  ok( $p->expand_entities() == 1, 'expand_entities should be true after being set to true' );
+  # TEST
+  ok( $p->load_ext_dtd() == 1, 'load_ext_dtd should be true after expand_entities is set to true' );
 }
 
 {

--- a/t/48_rt118032_xxe.t
+++ b/t/48_rt118032_xxe.t
@@ -1,0 +1,128 @@
+# -*- cperl -*-
+
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+
+use XML::LibXML;
+
+# Parser with default options should expand predefined entities.
+{
+    my $XML = <<'EOT';
+<?xml version="1.0" encoding="UTF-8"?>
+<EXAMPLE>&apos;&quot;&#38;</EXAMPLE>
+EOT
+
+    my $sys_line = <<'EOT';
+<EXAMPLE>'"&amp;</EXAMPLE>
+EOT
+
+    chomp ($sys_line);
+
+    my $parser = XML::LibXML->new();
+    my $XML_DOC = $parser->load_xml( string => $XML);
+    my $xml_string = $XML_DOC->toString();
+
+    # TEST
+    ok (scalar($xml_string =~ m{\Q$sys_line\E}),
+        "predefined entities should be expanded by default"
+    );
+}
+
+
+# Parser with default options should not expand internal entities
+# (Note that billion laughs attack is tested for in t/35huge_mode.t)
+{
+    my $XML = <<'EOT';
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE EXAMPLE SYSTEM "example.dtd" [
+<!ENTITY xml "Extensible Markup Language">
+]>
+<EXAMPLE>&xml;</EXAMPLE>
+EOT
+
+    my $sys_line = <<'EOT';
+<EXAMPLE>&xml;</EXAMPLE>
+EOT
+
+    chomp ($sys_line);
+
+    my $parser = XML::LibXML->new();
+    my $XML_DOC = $parser->load_xml( string => $XML);
+    my $xml_string = $XML_DOC->toString();
+
+    # TEST
+    ok (scalar($xml_string =~ m{\Q$sys_line\E}),
+        "internal entities should not be expanded by default"
+    );
+}
+
+# Parser with default options should not load external DTD
+{
+    my $XML = <<'EOT';
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE m PUBLIC "-//B/A/EN" "http://example.com">
+<rss version="2.0">
+<channel>
+    <link>example.com</link>
+    <description>DTD</description>
+    <item>
+        <title>DTD</title>
+        <link>example.com</link>
+        <description>Remote DTD</description>
+    </item>
+</channel>
+</rss>
+EOT
+
+    my $parser = XML::LibXML->new();
+    my $xml_string = eval {
+	my $XML_DOC = $parser->load_xml( string => $XML );
+        return $XML_DOC->toString();
+    };
+
+    # TEST
+    ok (scalar(!$@ && $xml_string),
+        "external DTD should not be loaded by default"
+    );
+}
+
+# Parser with default options should not load external entities
+{
+    my $XML = <<'EOT';
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE title [ <!ELEMENT title ANY >
+<!ENTITY xxe SYSTEM "file:///etc/nonexistent" >]>
+<rss version="2.0">
+<channel>
+    <link>example.com</link>
+    <description>XXE</description>
+    <item>
+        <title>&xxe;</title>
+        <link>example.com</link>
+        <description>XXE here</description>
+    </item>
+</channel>
+</rss>
+EOT
+
+    my $sys_line = <<'EOT';
+<title>&xxe;</title>
+EOT
+
+    chomp ($sys_line);
+
+    my $parser = XML::LibXML->new();
+    my $xml_string = eval {
+	my $XML_DOC = $parser->load_xml( string => $XML );
+        return $XML_DOC->toString();
+    };
+
+    # TEST
+    ok (scalar(!$@ && $xml_string =~ m{\Q$sys_line\E}),
+        "external entities should not be expanded by default"
+    );
+}
+
+1;


### PR DESCRIPTION
This is a first pass at disabling XXE attacks by default, bringing XML::LibXML in line with the libxml2 upstream defaults, which were changed in 2013.  The original libxml2 CVEs are here: https://www.openwall.com/lists/oss-security/2013/02/22/3

OWASP cheatsheet on libxml2 usage recommends disabling those options:
https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#libxml2

Related XML::LibXML bug: https://rt.cpan.org/Public/Bug/Display.html?id=118032

I have included a test to show that this doesn't affect expansions such as &#38; as mentioned in that bug report.