### PR TITLE
Allow to parse XML Schema without accessing network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ perl:
     - "5.26"
     - "5.24"
     - "5.22"
-    - "5.20"
-    - "5.18"
-    - "5.16"
 before_install:
     - "sudo apt-get update"
     - "sudo apt-get --no-install-recommends install libxml2-dev"

--- a/LibXML.pm
+++ b/LibXML.pm
@@ -2102,10 +2102,10 @@ sub new {
 
     my $self = undef;
     if ( defined $args{location} ) {
-        $self = $class->parse_location( $args{location} );
+        $self = $class->parse_location( $args{location}, XML::LibXML->_parser_options(\%args), $args{recover} );
     }
     elsif ( defined $args{string} ) {
-        $self = $class->parse_buffer( $args{string} );
+        $self = $class->parse_buffer( $args{string}, XML::LibXML->_parser_options(\%args), $args{recover} );
     }
 
     return $self;

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -7487,11 +7487,14 @@ DESTROY( self )
 
 
 xmlSchemaPtr
-parse_location( self, url )
+parse_location( self, url, parser_options = 0, recover = FALSE )
         char * url
+        int parser_options
+        bool recover
     PREINIT:
         const char * CLASS = "XML::LibXML::Schema";
         xmlSchemaParserCtxtPtr rngctxt = NULL;
+        xmlExternalEntityLoader old_ext_ent_loader = NULL;
         PREINIT_SAVED_ERROR
     CODE:
         INIT_ERROR_HANDLER;
@@ -7509,20 +7512,32 @@ parse_location( self, url )
                                   (xmlSchemaValidityWarningFunc)LibXML_error_handler_ctx,
                                   saved_error );
 
+        if ( EXTERNAL_ENTITY_LOADER_FUNC == NULL && (parser_options & XML_PARSE_NONET) ) {
+            old_ext_ent_loader = xmlGetExternalEntityLoader();
+            xmlSetExternalEntityLoader( xmlNoNetExternalEntityLoader );
+        }
+
         RETVAL = xmlSchemaParse( rngctxt );
+
+        if ( EXTERNAL_ENTITY_LOADER_FUNC == NULL && (parser_options & XML_PARSE_NONET) )
+            xmlSetExternalEntityLoader( (xmlExternalEntityLoader)old_ext_ent_loader );
+
         xmlSchemaFreeParserCtxt( rngctxt );
 	CLEANUP_ERROR_HANDLER;
-        REPORT_ERROR((RETVAL == NULL) ? 0 : 1);
+        REPORT_ERROR((RETVAL == NULL) ? 0 : recover);
     OUTPUT:
         RETVAL
 
 
 xmlSchemaPtr
-parse_buffer( self, perlstring )
+parse_buffer( self, perlstring, parser_options = 0, recover = FALSE )
         SV * perlstring
+        int parser_options
+        bool recover
     PREINIT:
         const char * CLASS = "XML::LibXML::Schema";
         xmlSchemaParserCtxtPtr rngctxt = NULL;
+        xmlExternalEntityLoader old_ext_ent_loader = NULL;
         char * string = NULL;
         STRLEN len    = 0;
         PREINIT_SAVED_ERROR
@@ -7547,10 +7562,19 @@ parse_buffer( self, perlstring )
                                   (xmlSchemaValidityWarningFunc)LibXML_error_handler_ctx,
                                   saved_error );
 
+        if ( EXTERNAL_ENTITY_LOADER_FUNC == NULL && (parser_options & XML_PARSE_NONET) ) {
+            old_ext_ent_loader = xmlGetExternalEntityLoader();
+            xmlSetExternalEntityLoader( xmlNoNetExternalEntityLoader );
+        }
+
         RETVAL = xmlSchemaParse( rngctxt );
+
+        if ( EXTERNAL_ENTITY_LOADER_FUNC == NULL && (parser_options & XML_PARSE_NONET) )
+            xmlSetExternalEntityLoader( (xmlExternalEntityLoader)old_ext_ent_loader );
+
         xmlSchemaFreeParserCtxt( rngctxt );
         CLEANUP_ERROR_HANDLER;
-        REPORT_ERROR((RETVAL == NULL) ? 0 : 1);
+        REPORT_ERROR((RETVAL == NULL) ? 0 : recover);
     OUTPUT:
         RETVAL
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -207,6 +207,7 @@ test/relaxng/schema.rng
 test/schema/badschema.xsd
 test/schema/demo.xml
 test/schema/invaliddemo.xml
+test/schema/net.xsd
 test/schema/schema.xsd
 test/textReader/countries.xml
 test/xinclude/entity.txt

--- a/docs/libxml.dbk
+++ b/docs/libxml.dbk
@@ -5830,12 +5830,15 @@ $doc = XML::LibXML-&gt;new-&gt;parse_file($url);</programlisting>
 
                 <listitem>
                     <funcsynopsis>
-                        <funcsynopsisinfo>$xmlschema = XML::LibXML::Schema-&gt;new( location =&gt; $filename_or_url );
-$xmlschema = XML::LibXML::Schema-&gt;new( string =&gt; $xmlschemastring );</funcsynopsisinfo>
+                        <funcsynopsisinfo>$xmlschema = XML::LibXML::Schema-&gt;new( location =&gt; $filename_or_url, no_network =&gt; 1 );
+$xmlschema = XML::LibXML::Schema-&gt;new( string =&gt; $xmlschemastring, no_network =&gt; 1 );</funcsynopsisinfo>
                     </funcsynopsis>
 
-                    <para>The constructor of XML::LibXML::Schema may get called with either one of two parameters. The parameter tells the class from which
-                    source it should generate a validation schema. It is important, that each schema only have a single source.</para>
+                    <para>The constructor of XML::LibXML::Schema needs to be called with list of parameters. At least location or string parameter is required to
+                    specify source of schema. Optional parameter no_network set to 1 cause that parser would not access network and optional parameter recover
+                    set 1 cause that parser would not call die() on errors.</para>
+
+                    <para>It is important, that each schema only have a single source.</para>
 
                 <para>The location parameter allows one to parse a schema
                     from the filesystem or a URL.</para>

--- a/test/schema/net.xsd
+++ b/test/schema/net.xsd
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:import namespace="http://example.com/namespace" schemaLocation="http://example.com/xml.xsd"/>
+</xsd:schema>


### PR DESCRIPTION
New optional parameter "no_network => 1" may be added to
XML::LibXML::Schema->new() constructor to disallow network
access when parsing supplied XML Schema.

Disabling network access when parsing XML is needed to prevent
security related problems and also to ensure that for parsing
is not needed internet connection.