### PR TITLE
When we set option complete_attributes, it will also enable load_ext_dtd

### DIFF
--- a/LibXML.pm
+++ b/LibXML.pm
@@ -367,6 +367,7 @@ sub new {
       # parser flags
       $opts{no_blanks} = !$opts{keep_blanks} if exists($opts{keep_blanks}) and !exists($opts{no_blanks});
       $opts{load_ext_dtd} = $opts{expand_entities} if exists($opts{expand_entities}) and !exists($opts{load_ext_dtd});
+      $opts{load_ext_dtd} = $opts{complete_attributes} if exists($opts{complete_attributes}) and !exists($opts{load_ext_dtd});
 
       for (keys %OUR_FLAGS) {
 	$self->{$OUR_FLAGS{$_}} = delete $opts{$_};
@@ -667,6 +668,9 @@ sub load_ext_dtd {
 
 sub complete_attributes {
     my $self = shift;
+    if (scalar(@_) and $_[0]) {
+      return $self->__parser_option(XML_PARSE_DTDATTR | XML_PARSE_DTDLOAD,1);
+    }
     return $self->__parser_option(XML_PARSE_DTDATTR,@_);
 }
 

--- a/t/06elements.t
+++ b/t/06elements.t
@@ -525,7 +525,7 @@ EOF
         {
             my $attr = $root->getAttributeNode('fixed');
             # TEST*$xml
-            is (ref($attr), 'XML::LibXML::Attr', ' TODO : Add test name');
+            is (ref($attr), 'XML::LibXML::Attr', ' Complete attributes');
             # TEST*$xml
             is ($attr->value,'foo', ' TODO : Add test name');
             # TEST*$xml

--- a/t/52completeattributes.t
+++ b/t/52completeattributes.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+
+use Test::More 0.98;
+
+my $dtdattr = << "END";
+<?xml version="1.0"?>
+<!DOCTYPE root [
+<!ELEMENT root (elem)*>
+<!ELEMENT elem EMPTY>
+<!ATTLIST elem a (b | c) "b">
+]>
+<root>
+	<elem/>
+</root>
+END
+
+my $completed = << "END";
+<?xml version="1.0"?>
+<!DOCTYPE root [
+<!ELEMENT root (elem)*>
+<!ELEMENT elem EMPTY>
+<!ATTLIST elem a (b | c) "b">
+]>
+<root>
+	<elem a="b"/>
+</root>
+END
+
+my $notcompleted = << "END";
+<?xml version="1.0"?>
+<!DOCTYPE root [
+<!ELEMENT root (elem)*>
+<!ELEMENT elem EMPTY>
+<!ATTLIST elem a (b | c) "b">
+]>
+<root>
+	<elem/>
+</root>
+END
+
+use XML::LibXML;
+
+my $parser = new XML::LibXML;
+$parser->complete_attributes(1);
+
+my $dom = $parser->load_xml(string => $dtdattr);
+is($dom, $completed, "Complete attributes from DTD using setter");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr, complete_attributes => 1);
+is($dom, $completed, "Complete attributes from DTD passing hash");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr, expand_entities => 1, complete_attributes => 1);
+is($dom, $completed, "Complete attributes from DTD passing hash (+ another option)");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr, expand_entities => 1, complete_attributes => 0);
+is($dom, $notcompleted, "Do not complete attributes (complete_attributes set to false)");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr, complete_attributes => 0);
+is($dom, $notcompleted, "Do not complete attributes (only one option, complete_attributes set to false)");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr, expand_entities => 1);
+is($dom, $notcompleted, "Do not complete attributes (one dtd related option, but complete_attributes not given)");
+
+$dom = XML::LibXML->load_xml(string => $dtdattr);
+is($dom, $notcompleted, "Do not complete attributes (no option)");
+
+
+done_testing;
+


### PR DESCRIPTION
Hello,

First, THANK YOU a lot for maintaining this great module :heart: 

I noticed that XML::LibXML is not setting `load_ext_dtd` implicitly when we set `complete_attributes` from both setter and option. It is not the same behavior than `expand_entities` nor `xmllint --dtdattr` (`xmllint | grep dtdattr` says `--dtdattr : loaddtd + populate the tree with inherited attributes`)

It means that `XML::LibXML->load_xml(string => $xml, expand_entities => 1, complete_attributes => 1);` will not do the same than `XML::LibXML->load_xml(string => $xml, complete_attributes => 1);`

As any other dtd related option, I think we want to set implicitly the `load_ext_dtd` option.

This pull request is doing this change and I provide a set of tests that will fail without the fix.
In `t/06elements.t`, it is inhibited by the fact that another DTD related option is given. 

In addition, I have the feeling that the documentation is not totally correct. For instance 
https://metacpan.org/pod/distribution/XML-LibXML/lib/XML/LibXML/Parser.pod#load_ext_dtd says *Unless specified, XML::LibXML sets this option to 1* but I feel it's wrong. 
  
Same with https://metacpan.org/pod/distribution/XML-LibXML/lib/XML/LibXML/Parser.pod#expand_entities says that *default is 1* and I feel the contrary.

Concerning this last point about documentation, I just report my feelings, asking for your confirmation/thoughts.

For the rest, I hope this PR will fit your merge quality criteria.

Best regards and once again thank you for this amazing module.

Thibault

