### PR TITLE
Default value for option load_ext_dtd is 0. Default value for option expand_entities is 0

### DIFF
--- a/docs/libxml.dbk
+++ b/docs/libxml.dbk
@@ -1075,7 +1075,7 @@ $parser = XML::LibXML-&gt;new({option=>value, ...});</funcsynopsisinfo>
 			      set a different default set of options.
 			      Unless specified otherwise, the options
 			      <literal>load_ext_dtd</literal>, and
-			      <literal>expand_entities</literal> are set to 1.
+			      <literal>expand_entities</literal> are set to 0.
 			      See <xref linkend="parser-options"/> for a list of libxml2 parser's options.
 			    </para>
                         </listitem>
@@ -1697,7 +1697,7 @@ local $XML::LibXML::setTagCompression = 1;</programlisting>
             <term>expand_entities</term>
             <listitem>
 	      <para>/parser, reader/</para>
-              <para>substitute entities; possible values are 0 and 1; default is 1</para>
+              <para>substitute entities; possible values are 0 and 1; default is 0</para>
 	      <para>Note that although this flag disables entity substitution, it
 	      does not prevent the parser from loading external entities;
 	      when substitution of an external entity is disabled, the
@@ -1752,7 +1752,7 @@ $parser->input_callbacks($c);
             <listitem>
 	      <para>/parser, reader/</para>
               <para>load the external DTD subset while parsing; possible values are 0 and 1. Unless specified,
-		XML::LibXML sets this option to 1.</para>
+		XML::LibXML sets this option to 0.</para>
               <para>This flag is also required for DTD Validation, to provide complete attribute,
                 and to expand entities, regardless if the document has an internal subset.
                 Thus switching off external DTD loading, will disable entity expansion,


### PR DESCRIPTION
Hello,

Following my other PR I double checked and I propose this documentation update.
Seems related to a recent security change (align to libxml2 behavior concerning xxe security issue)

```perl 
#!/usr/bin/env perl

use XML::LibXML;

my $parser = XML::LibXML->new();
print "Test default values\n";
print "Default expand_entities() [" . $parser->expand_entities() ."]\n";
print "Default load_ext_dtd() [" . $parser->load_ext_dtd() ."]\n";

$parser = XML::LibXML->new();
$parser->expand_entities(1);
print "Set expand_entities then test default values :\n";
print "expand_entities() [" . $parser->expand_entities() ."]\n";
print "load_ext_dtd() [" . $parser->load_ext_dtd() ."]\n";

$parser = XML::LibXML->new();
$parser->expand_entities(1);
$parser->set_option(load_ext_dtd => 0);
print "Set expand_entities and unset load_ext_dtd then test default values :\n";
print "expand_entities() [" . $parser->expand_entities() ."]\n";
print "load_ext_dtd() [" . $parser->load_ext_dtd() ."]\n";
```

Is producing : 

```
Test default values
Default expand_entities() [0]
Default load_ext_dtd() [0]
Set expand_entities then test default values :
expand_entities() [1]
load_ext_dtd() [1]
Set expand_entities and unset load_ext_dtd then test default values :
expand_entities() [1]
load_ext_dtd() [0]
```

Best regards.

Thibault