### PR TITLE
Lazy load Data::Dumper

### DIFF
--- a/lib/XML/LibXML/Error.pm
+++ b/lib/XML/LibXML/Error.pm
@@ -254,7 +254,7 @@ sub as_string {
 
 sub dump {
   my ($self)=@_;
-  use Data::Dumper;
+  require Data::Dumper;
   return Data::Dumper->new([$self],['error'])->Dump;
 }
 


### PR DESCRIPTION
Data::Dumper is only used by the `dump` function.
`dump` is used for error reporting and debugging.
We should not load this module unless needed.