### PR TITLE
use utf8 instead of Encode

### DIFF
--- a/lib/XML/LibXML/Error.pm
+++ b/lib/XML/LibXML/Error.pm
@@ -14,8 +14,6 @@ use warnings;
 # To avoid a "Deep recursion on subroutine as_string" warning
 no warnings 'recursion';
 
-use Encode ();
-
 use vars qw(@error_domains $VERSION $WARNINGS);
 use Carp;
 use overload
@@ -243,7 +241,9 @@ sub as_string {
       # warnings.  This has the pleasing benefit of making the test suite
       # run warning-free.
       no warnings 'utf8';
-      my $context = Encode::encode('utf8', $self->{context}, Encode::FB_DEFAULT);
+
+      my $context = $self->{context};
+      utf8::encode($context);
       $msg.=$context."\n";
       $context = substr($context,0,$self->{column});
       $context=~s/[^\t]/ /g;


### PR DESCRIPTION
utf8::encode can be used instead of the Encode::encode
function in this case.

This is avoiding loading Encode where unneeded and reduces
memory footprint.

Check to confirm using `utf8::encode` provides the same behavior:
```
╰─> perl -e 'my $x = "\x{100}"; use Devel::Peek; Dump $x; utf8::encode($x); Dump $x; my $y = "\x{100}"; use Encode; my $z = Encode::encode( utf8 => $y, Encode::FB_DEFAULT); Dump $z'
SV = PV(0x7fd2cf00b650) at 0x7fd2cf8119c8
  REFCNT = 1
  FLAGS = (POK,IsCOW,pPOK,UTF8)
  PV = 0x7fd2ced0e490 "\304\200"\0 [UTF8 "\x{100}"]
  CUR = 2
  LEN = 10
  COW_REFCNT = 1
SV = PV(0x7fd2cf00b650) at 0x7fd2cf8119c8
  REFCNT = 1
  FLAGS = (POK,IsCOW,pPOK)
  PV = 0x7fd2ced0e490 "\304\200"\0
  CUR = 2
  LEN = 10
  COW_REFCNT = 1
SV = PV(0x7fd2cf00b7c0) at 0x7fd2cf81e278
  REFCNT = 1
  FLAGS = (POK,pPOK)
  PV = 0x7fd2d910f3c0 "\304\200"\0
  CUR = 2
  LEN = 10
```