### PR TITLE
XML::LibXML::Error - use UTF-8 encoding for output

### DIFF
--- a/lib/XML/LibXML/Error.pm
+++ b/lib/XML/LibXML/Error.pm
@@ -243,7 +243,7 @@ sub as_string {
       # warnings.  This has the pleasing benefit of making the test suite
       # run warning-free.
       no warnings 'utf8';
-      my $context = Encode::encode('utf8', $self->{context}, Encode::FB_DEFAULT);
+      my $context = Encode::encode('UTF-8', $self->{context});
       $msg.=$context."\n";
       $context = substr($context,0,$self->{column});
       $context=~s/[^\t]/ /g;


### PR DESCRIPTION
The UTF-8 encoding will (by default) encode replacement characters for noncharacters, surrogates, and codepoints outside the Unicode range, whereas the 'utf8' encoding will blindly encode to Perl's internal approximation of UTF-8 that has no such restrictions.

Also, remove the explicit specification of FB_DEFAULT, since specifying it will remove the implicit LEAVE_SRC option causing `$self->{context}` to get modified in place.