### PR TITLE
Correctly detect undef values in Sv2C

### DIFF
--- a/perl-libxml-mm.c
+++ b/perl-libxml-mm.c
@@ -1118,7 +1118,7 @@ Sv2C( SV* scalar, const xmlChar *encoding )
     dTHX;
 
     xs_warn("SV2C: start!\n");
-    if ( scalar != NULL && scalar != &PL_sv_undef ) {
+    if ( scalar != NULL && SvOK(scalar) ) {
         STRLEN len = 0;
         char * t_pv =SvPV(scalar, len);
         xmlChar* ts = NULL;


### PR DESCRIPTION
This test program

```perl
use warnings;
use XML::LibXML;

my $test = XML::LibXML::Text->new({}->{bar});
```

produces the following warning:

```shell
$ perl ~/test.pl
Use of uninitialized value in subroutine entry at /home/sven/test.pl line 4.
```

This apparently happens, because `Sv2C` tries to catch `undef` values by comparing the memory location of the scalar in question to `&PL_sv_undef`. While `PL_sv_undef` certainly is an `undef` value, not all `undef` values share its memory location. The added commit fixes this, by using `SvOK` to correctly detect all `undef` values.