### PR TITLE
Fix bug where Wrapper->mm_args value was used without considering value specified in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -68,11 +68,15 @@ my %prereqs = (
   "warnings" => 0,
 );
 
-my %xsbuild = (
+my %xsbuild_concat = (
   DEFINE  => '-DHAVE_UTF8',
   OBJECT  => '$(O_FILES)',
-  Alien::Base::Wrapper->mm_args,
 );
+my %xsbuild = Alien::Base::Wrapper->mm_args;  # Might contain a definition of DEFINE, must thus concatenate.
+while (my($k,$v) = each %xsbuild_concat) {
+  my $base_val = $xsbuild{$k};
+  $xsbuild{$k} = defined $base_val ? $base_val.' '.$v : $v;
+}
 
 my %WriteMakefileArgs = (
   "NAME" => "XML::LibXML",


### PR DESCRIPTION
On my current compilation (on Cygwin) Alien::Base::Wrapper->mm_args contains a 'DEFINE' value of '-DLIBXML_STATIC'.  The Makefile.PL was using that value without adding the required '-DHAVE_UTF8', because the hash was combined by overwriting values instead of concatenating them. It was thus failing all Unicode tests because it was compiled without the required define. With this patch it now works correctly.  Note that if we would like to support concatenation of 'LIBS', it would have to be modified to work also with arrays.