### PR TITLE
libxml-mm: Fix function prototypes in function pointers

### DIFF
--- a/perl-libxml-mm.c
+++ b/perl-libxml-mm.c
@@ -121,7 +121,7 @@ PmmFreeHashTable(xmlHashTablePtr table)
 extern SV* PROXY_NODE_REGISTRY_MUTEX;
 
 /* Utility method used by PmmDumpRegistry */
-void PmmRegistryDumpHashScanner(void * payload, void * data, xmlChar * name)
+void PmmRegistryDumpHashScanner(void * payload, void * data, const xmlChar * name)
 {
 	LocalProxyNodePtr lp = (LocalProxyNodePtr) payload;
 	ProxyNodePtr node = (ProxyNodePtr) lp->proxy;
@@ -215,7 +215,7 @@ PmmRegisterProxyNode(ProxyNodePtr proxy)
 /* PP: originally this was static inline void, but on AIX the compiler
    did not chew it, so I'm removing the inline */
 static void
-PmmRegistryHashDeallocator(void *payload, xmlChar *name)
+PmmRegistryHashDeallocator(void *payload, const xmlChar *name)
 {
 	Safefree((LocalProxyNodePtr) payload);
 }
@@ -279,7 +279,7 @@ PmmRegistryREFCNT_dec(ProxyNodePtr proxy)
  * internal, used by PmmCloneProxyNodes
  */
 void *
-PmmRegistryHashCopier(void *payload, xmlChar *name)
+PmmRegistryHashCopier(void *payload, const xmlChar *name)
 {
 	ProxyNodePtr proxy = ((LocalProxyNodePtr) payload)->proxy;
 	LocalProxyNodePtr lp;


### PR DESCRIPTION
This is now detected with latest clang16+

Fixes
error: incompatible function pointer types passing 'void (void *, void *, xmlChar *)' (aka 'void (void *, void *, unsigned char *)') to parameter of type 'xmlHashScanner' (aka 'void (*)(void *, void *, const unsigned char *)') [-Wincompatible-function-pointer-types]
                xmlHashScan(r, PmmRegistryDumpHashScanner, NULL);

Signed-off-by: Khem Raj <raj.khem@gmail.com>