### PR TITLE
Fix external entity loader

### DIFF
--- a/LibXML.xs
+++ b/LibXML.xs
@@ -151,6 +151,7 @@ typedef enum {
 
 /* this should keep the default */
 static xmlExternalEntityLoader LibXML_old_ext_ent_loader = NULL;
+static xmlExternalEntityLoader LibXML_old_ext_ent_loader_global = NULL;
 
 /* global external entity loader */
 SV *EXTERNAL_ENTITY_LOADER_FUNC = (SV *)NULL;
@@ -2813,16 +2814,17 @@ _externalEntityLoader( loader )
         SV* loader
     CODE:
         {
-            RETVAL = EXTERNAL_ENTITY_LOADER_FUNC;
-            if(EXTERNAL_ENTITY_LOADER_FUNC == NULL)
-            {
+            RETVAL = EXTERNAL_ENTITY_LOADER_FUNC == NULL ? &PL_sv_undef : EXTERNAL_ENTITY_LOADER_FUNC;
+            if (SvOK(loader)) {
                 EXTERNAL_ENTITY_LOADER_FUNC = newSVsv(loader);
-            }
-
-            if (LibXML_old_ext_ent_loader == NULL )
-            {
-                LibXML_old_ext_ent_loader = xmlGetExternalEntityLoader();
-                xmlSetExternalEntityLoader((xmlExternalEntityLoader)LibXML_load_external_entity);
+                if (LibXML_old_ext_ent_loader_global == NULL) {
+                    LibXML_old_ext_ent_loader_global = xmlGetExternalEntityLoader();
+                    xmlSetExternalEntityLoader((xmlExternalEntityLoader)LibXML_load_external_entity);
+                }
+            } else {
+                EXTERNAL_ENTITY_LOADER_FUNC = NULL;
+                xmlSetExternalEntityLoader((xmlExternalEntityLoader)LibXML_old_ext_ent_loader_global);
+                LibXML_old_ext_ent_loader_global = NULL;
             }
         }
     OUTPUT:

--- a/t/49global_extent_after_no_network.t
+++ b/t/49global_extent_after_no_network.t
@@ -1,0 +1,58 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use XML::LibXML;
+
+use IO::Handle;
+
+STDOUT->autoflush(1);
+STDERR->autoflush(1);
+
+if (XML::LibXML::LIBXML_VERSION() < 20627)
+{
+    plan skip_all => "skipping for libxml2 < 2.6.27";
+}
+else
+{
+    plan tests => 2;
+}
+
+sub handler_global {
+  return join(",","global",@_);
+}
+
+
+my $xml = <<'EOF';
+<?xml version="1.0"?>
+<!DOCTYPE foo [
+<!ENTITY a PUBLIC "//foo/bar/b" "http:///invalid-url">
+]>
+<root>
+  <a>&a;</a>
+</root>
+EOF
+my ($xml_out_global) = ($xml);
+$xml_out_global =~ s{&a;}{global,http:///invalid-url,//foo/bar/b};
+
+subtest "initial parse without network" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1, no_network => 1 });
+  my ($doc);
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  like($err, qr/^I\/O error/, "no_network error");
+  is($doc, undef, "doc is undef");
+};
+
+XML::LibXML::externalEntityLoader(sub { handler_global(@_) });
+
+subtest "parse with global ext_ent_handler" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my ($doc);
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  is($err || 0, 0, "error not set");
+  is($doc && $doc->toString(), $xml_out_global, "document matches");
+};
+

--- a/t/49global_extent_reset.t
+++ b/t/49global_extent_reset.t
@@ -1,0 +1,68 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use XML::LibXML;
+
+use IO::Handle;
+
+STDOUT->autoflush(1);
+STDERR->autoflush(1);
+
+if (XML::LibXML::LIBXML_VERSION() < 20627)
+{
+    plan skip_all => "skipping for libxml2 < 2.6.27";
+}
+else
+{
+    plan tests => 5;
+}
+
+sub handler_global {
+  return join(",","global",@_);
+}
+
+
+my $xml = <<'EOF';
+<?xml version="1.0"?>
+<!DOCTYPE foo [
+<!ENTITY a PUBLIC "//foo/bar/b" "http:///invalid-url">
+]>
+<root>
+  <a>&a;</a>
+</root>
+EOF
+my ($xml_out_global) = ($xml);
+$xml_out_global =~ s{&a;}{global,http:///invalid-url,//foo/bar/b};
+
+subtest "initial parse with network" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my ($doc);
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  like($err, qr/^http error/, "http error");
+  is($doc, undef, "doc is undef");
+};
+
+is (XML::LibXML::externalEntityLoader(sub { handler_global(@_) }), undef, "previous handler is undef");
+
+subtest "parse with global ext_ent_handler" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my ($doc);
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  is($err || 0, 0, "error not set");
+  is($doc && $doc->toString(), $xml_out_global, "document matches");
+};
+
+is(ref(XML::LibXML::externalEntityLoader(undef)), "CODE", "previous handler is code ref");
+
+subtest "afterwards parse without network" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1, no_network => 1 });
+  my ($doc);
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  like($err, qr/^I\/O error/, "no_network error");
+  is($doc, undef, "doc is undef");
+};

--- a/t/49global_private_extent.t
+++ b/t/49global_private_extent.t
@@ -1,0 +1,89 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use XML::LibXML;
+
+use IO::Handle;
+
+STDOUT->autoflush(1);
+STDERR->autoflush(1);
+
+if (XML::LibXML::LIBXML_VERSION() < 20627)
+{
+    plan skip_all => "skipping for libxml2 < 2.6.27";
+}
+else
+{
+    plan tests => 5;
+}
+
+sub handler_private {
+  return join(",","private",@_);
+}
+
+sub handler_global {
+  return join(",","global",@_);
+}
+
+
+my $xml = <<'EOF';
+<?xml version="1.0"?>
+<!DOCTYPE foo [
+<!ENTITY a PUBLIC "//foo/bar/b" "http:///invalid-url">
+]>
+<root>
+  <a>&a;</a>
+</root>
+EOF
+my ($xml_out_private, $xml_out_global) = ($xml, $xml);
+$xml_out_private =~ s{&a;}{private,http:///invalid-url,//foo/bar/b};
+$xml_out_global =~ s{&a;}{global,http:///invalid-url,//foo/bar/b};
+
+subtest "initial parse with private ext_ent_handler" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1, ext_ent_handler => \&handler_private });
+  my $doc;
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  is($err || 0, 0, "error not set");
+  is($doc && $doc->toString(), $xml_out_private, "document matches");
+};
+
+subtest "second parse without any handlers" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my $doc;
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  like($err,qr/^http error/,"http error");
+};
+
+XML::LibXML::externalEntityLoader(sub { handler_global(@_) });
+
+subtest "global ext_ent_handler overrides private ext_ent_handler" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my $doc;
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  is($err || 0, 0, "error not set");
+  is($doc && $doc->toString(), $xml_out_global, 'document matches' );
+};
+
+XML::LibXML::externalEntityLoader(undef);
+
+subtest "afterwards parse with private ext_ent_handler" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1, ext_ent_handler => \&handler_private });
+  my $doc;
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  is($err || 0, 0, "error not set");
+  is($doc && $doc->toString(), $xml_out_private, "document matches");
+};
+
+subtest "afterwards parse without any handlers" => sub {
+  my $parser = XML::LibXML->new({ expand_entities => 1 });
+  my $doc;
+  eval { $doc = $parser->parse_string($xml); };
+  my $err = $@;
+  like($err,qr/^http error/,"http error");
+};


### PR DESCRIPTION
I found the following issues with `externalEntityLoader(...)` when trying to use it for a single XML Schema parse without affecting later other parses:

- `externalEntityLoader(...)` does not take effect when
  - `ext_ent_handler` has been passed in a previous parser instantiation  - `t/49global_private_extent.t`
  - `no_network` has been passed in a previous parser instantiation - `t/49global_extend_after_no_network`.t
- after calling `externEntityLoader` it is not possible to clear it: setting it to `undef`
  - still keeps `LibXML_load_external_entity` installed, which e.g. does not check `no_network` - `t49/global_extent_reset.t`
  - still hides an `ext_ent_handler` passed to a later parser instantiation - `t49/global_private_extent.t` test 4
- the first call to `externalEntityLoader` sometimes causes a segfault (at least in some cases when the return value is used)

and would suggest this PR as a solution:

- Make `externalEntityLoader` and `ext_ent_handler` independent, including their storage of 'old handler', with `externalEntityLoader` overriding `ext_ent_handler` like now
- Interpret `externalEntityLoader(undef)` as 'fully undo setting `externalEntityLoader'` 
- Return `&PL_sv_undef` instead of `NULL` when no handler was previously set

Thanks for XML::LibXML!