### PR TITLE
don't use vars, use our

### DIFF
--- a/LibXML.pm
+++ b/LibXML.pm
@@ -13,11 +13,12 @@ package XML::LibXML;
 use strict;
 use warnings;
 
-use vars qw($VERSION $ABI_VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS
-            $skipDTD $skipXMLDeclaration $setTagCompression
-            $MatchCB $ReadCB $OpenCB $CloseCB %PARSER_FLAGS
-	    $XML_LIBXML_PARSE_DEFAULTS
-            );
+our (
+    $VERSION,
+    $skipDTD, $skipXMLDeclaration, $setTagCompression,
+    $MatchCB, $ReadCB, $OpenCB, $CloseCB,
+);
+
 use Carp;
 
 use constant XML_XMLNS_NS => 'http://www.w3.org/2000/xmlns/';
@@ -30,12 +31,10 @@ use IO::Handle; # for FH reads called as methods
 
 BEGIN {
 $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
-$ABI_VERSION = 2;
+our $ABI_VERSION = 2;
 require Exporter;
 use XSLoader ();
-@ISA = qw(Exporter);
-
-use vars qw($__PROXY_NODE_REGISTRY $__threads_shared $__PROXY_NODE_REGISTRY_MUTEX $__loaded);
+our @ISA = qw(Exporter);
 
 sub VERSION {
   my $class = shift;
@@ -57,7 +56,7 @@ sub VERSION {
 #-------------------------------------------------------------------------#
 # export information                                                      #
 #-------------------------------------------------------------------------#
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
                 all => [qw(
                            XML_ELEMENT_NODE
                            XML_ATTRIBUTE_NODE
@@ -116,11 +115,11 @@ sub VERSION {
 		 )],
                );
 
-@EXPORT_OK = (
+our @EXPORT_OK = (
               @{$EXPORT_TAGS{all}},
              );
 
-@EXPORT = (
+our @EXPORT = (
            @{$EXPORT_TAGS{all}},
           );
 
@@ -180,6 +179,7 @@ use constant XML_NAMESPACE_DECL          => 18;
 use constant XML_XINCLUDE_START          => 19;
 use constant XML_XINCLUDE_END            => 20;
 
+our ($__PROXY_NODE_REGISTRY, $__threads_shared, $__PROXY_NODE_REGISTRY_MUTEX, $__loaded);
 
 sub import {
   my $package=shift;
@@ -203,7 +203,7 @@ sub import {
     } elsif (!$__threads_shared) {
       croak("XML::LibXML already loaded without thread support. Too late to enable thread support!");
     }
-  } elsif (defined $XML::LibXML::__loaded) {
+  } elsif (defined $__loaded) {
     $__threads_shared=0 if not defined $__threads_shared;
   }
   __PACKAGE__->export_to_level(1,$package,grep !/^:threads(_shared)?$/,@_);
@@ -261,12 +261,12 @@ use constant {
   HTML_PARSE_NOERROR  => (1<<5),       # suppress error reports
 };
 
-$XML_LIBXML_PARSE_DEFAULTS = ( XML_PARSE_NODICT );
+our $XML_LIBXML_PARSE_DEFAULTS = ( XML_PARSE_NODICT );
 
 # this hash is made global so that applications can add names for new
 # libxml2 parser flags as temporary workaround
 
-%PARSER_FLAGS = (
+our %PARSER_FLAGS = (
   recover		 => XML_PARSE_RECOVER,
   expand_entities	 => XML_PARSE_NOENT,
   load_ext_dtd	         => XML_PARSE_DTDLOAD,
@@ -1415,8 +1415,7 @@ sub toStringEC14N {
 #-------------------------------------------------------------------------#
 package XML::LibXML::Document;
 
-use vars qw(@ISA);
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 
 sub actualEncoding {
   my $doc = shift;
@@ -1511,8 +1510,7 @@ sub insertPI {
 #-------------------------------------------------------------------------#
 package XML::LibXML::DocumentFragment;
 
-use vars qw(@ISA);
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 
 sub toString {
     my $self = shift;
@@ -1534,8 +1532,7 @@ sub toString {
 #-------------------------------------------------------------------------#
 package XML::LibXML::Element;
 
-use vars qw(@ISA);
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 use XML::LibXML qw(:ns :libxml);
 use XML::LibXML::AttributeHash;
 use Carp;
@@ -1773,8 +1770,7 @@ sub appendWellBalancedChunk {
 #-------------------------------------------------------------------------#
 package XML::LibXML::Text;
 
-use vars qw(@ISA);
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 
 sub attributes { return; }
 
@@ -1818,15 +1814,13 @@ sub replaceDataRegEx {
 
 package XML::LibXML::Comment;
 
-use vars qw(@ISA);
-@ISA = ('XML::LibXML::Text');
+our @ISA = ('XML::LibXML::Text');
 
 1;
 
 package XML::LibXML::CDATASection;
 
-use vars qw(@ISA);
-@ISA     = ('XML::LibXML::Text');
+our @ISA     = ('XML::LibXML::Text');
 
 1;
 
@@ -1834,8 +1828,7 @@ use vars qw(@ISA);
 # XML::LibXML::Attribute Interface                                        #
 #-------------------------------------------------------------------------#
 package XML::LibXML::Attr;
-use vars qw( @ISA ) ;
-@ISA = ('XML::LibXML::Node') ;
+our @ISA = ('XML::LibXML::Node') ;
 
 sub setNamespace {
     my ($self,$href,$prefix) = @_;
@@ -1856,8 +1849,7 @@ sub setNamespace {
 # this is still under construction
 #
 package XML::LibXML::Dtd;
-use vars qw( @ISA );
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 
 # at least DESTROY and CLONE_SKIP must be inherited
 
@@ -1867,8 +1859,7 @@ use vars qw( @ISA );
 # XML::LibXML::PI Interface                                               #
 #-------------------------------------------------------------------------#
 package XML::LibXML::PI;
-use vars qw( @ISA );
-@ISA = ('XML::LibXML::Node');
+our @ISA = ('XML::LibXML::Node');
 
 sub setData {
     my $pi = shift;
@@ -2179,7 +2170,7 @@ sub CLONE_SKIP { 1 }
 #-------------------------------------------------------------------------#
 package XML::LibXML::InputCallback;
 
-use vars qw($_CUR_CB @_GLOBAL_CALLBACKS @_CB_STACK $_CB_NESTED_DEPTH @_CB_NESTED_STACK);
+our ($_CUR_CB, @_GLOBAL_CALLBACKS, @_CB_STACK, $_CB_NESTED_DEPTH, @_CB_NESTED_STACK);
 
 BEGIN {
   $_CUR_CB = undef;
@@ -2364,7 +2355,7 @@ sub cleanup_callbacks {
     $self->lib_cleanup_callbacks() unless($_CB_NESTED_DEPTH);
 }
 
-$XML::LibXML::__loaded=1;
+$__loaded=1;
 
 1;
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -64,7 +64,6 @@ my %prereqs = (
   "overload" => 0,
   "parent" => 0,
   "strict" => 0,
-  "vars" => 0,
   "warnings" => 0,
 );
 

--- a/lib/XML/LibXML/AttributeHash.pm
+++ b/lib/XML/LibXML/AttributeHash.pm
@@ -6,8 +6,7 @@ use Scalar::Util qw//;
 use Tie::Hash;
 our @ISA = qw/Tie::Hash/;
 
-use vars qw($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 BEGIN
 {

--- a/lib/XML/LibXML/Boolean.pm
+++ b/lib/XML/LibXML/Boolean.pm
@@ -14,9 +14,7 @@ use XML::LibXML::Literal;
 use strict;
 use warnings;
 
-use vars qw ($VERSION);
-
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use overload
         '""' => \&value,

--- a/lib/XML/LibXML/Common.pm
+++ b/lib/XML/LibXML/Common.pm
@@ -19,18 +19,17 @@ use strict;
 use warnings;
 
 require Exporter;
-use vars qw( @ISA $VERSION @EXPORT @EXPORT_OK %EXPORT_TAGS);
 
-@ISA = qw(Exporter);
+our @ISA = qw(Exporter);
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use XML::LibXML qw(:libxml);
 
 #-------------------------------------------------------------------------#
 # export information                                                      #
 #-------------------------------------------------------------------------#
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
                 all => [qw(
                            ELEMENT_NODE
                            ATTRIBUTE_NODE
@@ -131,14 +130,14 @@ use XML::LibXML qw(:libxml);
                                )],
                );
 
-@EXPORT_OK = (
+our @EXPORT_OK = (
               @{$EXPORT_TAGS{encoding}},
               @{$EXPORT_TAGS{w3c}},
               @{$EXPORT_TAGS{libxml}},
               @{$EXPORT_TAGS{gdome}},
              );
 
-@EXPORT = (
+our @EXPORT = (
            @{$EXPORT_TAGS{encoding}},
            @{$EXPORT_TAGS{w3c}},
           );

--- a/lib/XML/LibXML/Devel.pm
+++ b/lib/XML/LibXML/Devel.pm
@@ -11,14 +11,11 @@ use warnings;
 
 use XML::LibXML;
 
-use vars qw ($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use 5.008_000;
 
 use parent qw(Exporter);
-
-use vars qw( @EXPORT @EXPORT_OK %EXPORT_TAGS );
 
 # This allows declaration	use XML::LibXML::Devel ':all';
 # If you do not need this, moving things directly into @EXPORT or @EXPORT_OK

--- a/lib/XML/LibXML/ErrNo.pm
+++ b/lib/XML/LibXML/ErrNo.pm
@@ -12,9 +12,8 @@ package XML::LibXML::ErrNo;
 
 use strict;
 use warnings;
-use vars qw($VERSION);
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use constant ERR_OK                               => 0;
 use constant ERR_INTERNAL_ERROR                   => 1;

--- a/lib/XML/LibXML/Error.pm
+++ b/lib/XML/LibXML/Error.pm
@@ -16,7 +16,6 @@ no warnings 'recursion';
 
 use Encode ();
 
-use vars qw(@error_domains $VERSION $WARNINGS);
 use overload
   '""' => \&as_string,
   'eq' => sub {
@@ -27,8 +26,8 @@ use overload
   },
   fallback => 1;
 
-$WARNINGS = 0; # 0: suppress, 1: report via warn, 2: report via die
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $WARNINGS = 0; # 0: suppress, 1: report via warn, 2: report via die
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use constant XML_ERR_NONE            => 0;
 use constant XML_ERR_WARNING         => 1; # A simple warning
@@ -65,7 +64,7 @@ use constant XML_ERR_FROM_MODULE     => 26; # The dynamically-loaded module modu
 use constant XML_ERR_FROM_I18N       => 27; # The module handling character conversion
 use constant XML_ERR_FROM_SCHEMATRONV=> 28; # The Schematron validator module
 
-@error_domains = ("", "parser", "tree", "namespace", "validity",
+our @error_domains = ("", "parser", "tree", "namespace", "validity",
                   "HTML parser", "memory", "output", "I/O", "ftp",
                   "http", "XInclude", "XPath", "xpointer", "regexp",
                   "Schemas datatype", "Schemas parser", "Schemas validity",

--- a/lib/XML/LibXML/Literal.pm
+++ b/lib/XML/LibXML/Literal.pm
@@ -15,8 +15,7 @@ use XML::LibXML::Number;
 use strict;
 use warnings;
 
-use vars qw ($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use overload
 		'""' => \&value,

--- a/lib/XML/LibXML/NodeList.pm
+++ b/lib/XML/LibXML/NodeList.pm
@@ -16,8 +16,7 @@ use XML::LibXML::Boolean;
 use XML::LibXML::Literal;
 use XML::LibXML::Number;
 
-use vars qw($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use overload
         '""' => \&to_literal,

--- a/lib/XML/LibXML/Number.pm
+++ b/lib/XML/LibXML/Number.pm
@@ -13,8 +13,7 @@ use XML::LibXML::Literal;
 use strict;
 use warnings;
 
-use vars qw ($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use overload
         '""' => \&value,

--- a/lib/XML/LibXML/Reader.pm
+++ b/lib/XML/LibXML/Reader.pm
@@ -13,8 +13,7 @@ use Carp;
 use strict;
 use warnings;
 
-use vars qw ($VERSION);
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use 5.008_000;
 
@@ -54,13 +53,12 @@ use constant {
     XML_READER_DONE      =>  5,
     XML_READER_ERROR     =>  6
 };
-use vars qw( @EXPORT @EXPORT_OK %EXPORT_TAGS );
 
 sub CLONE_SKIP { 1 }
 
 BEGIN {
 
-%EXPORT_TAGS = (
+our %EXPORT_TAGS = (
   types =>
   [qw(
     XML_READER_TYPE_NONE
@@ -94,8 +92,8 @@ BEGIN {
     XML_READER_ERROR
    )]
 );
-@EXPORT    = (@{$EXPORT_TAGS{types}},@{$EXPORT_TAGS{states}});
-@EXPORT_OK = @EXPORT;
+our @EXPORT    = (@{$EXPORT_TAGS{types}},@{$EXPORT_TAGS{states}});
+our @EXPORT_OK = @EXPORT;
 $EXPORT_TAGS{all}=\@EXPORT_OK;
 }
 

--- a/lib/XML/LibXML/SAX.pm
+++ b/lib/XML/LibXML/SAX.pm
@@ -12,9 +12,7 @@ package XML::LibXML::SAX;
 use strict;
 use warnings;
 
-use vars qw($VERSION @ISA);
-
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 use XML::LibXML;
 use XML::SAX::Base;

--- a/lib/XML/LibXML/SAX/Builder.pm
+++ b/lib/XML/LibXML/SAX/Builder.pm
@@ -15,13 +15,11 @@ use warnings;
 use XML::LibXML;
 use XML::NamespaceSupport;
 
-use vars qw ($VERSION);
-
 sub CLONE_SKIP {
   return $XML::LibXML::__threads_shared ? 0 : 1;
 }
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 sub new {
     my $class = shift;

--- a/lib/XML/LibXML/SAX/Generator.pm
+++ b/lib/XML/LibXML/SAX/Generator.pm
@@ -13,9 +13,8 @@ use strict;
 use warnings;
 
 use XML::LibXML;
-use vars qw ($VERSION);
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 sub CLONE_SKIP {
   return $XML::LibXML::__threads_shared ? 0 : 1;

--- a/lib/XML/LibXML/SAX/Parser.pm
+++ b/lib/XML/LibXML/SAX/Parser.pm
@@ -11,15 +11,14 @@ package XML::LibXML::SAX::Parser;
 
 use strict;
 use warnings;
-use vars qw($VERSION @ISA);
 
 use XML::LibXML;
 use XML::LibXML::Common qw(:libxml);
 use XML::SAX::Base;
 use XML::SAX::DocumentLocator;
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
-@ISA = ('XML::SAX::Base');
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our @ISA = ('XML::SAX::Base');
 
 sub CLONE_SKIP {
   return $XML::LibXML::__threads_shared ? 0 : 1;

--- a/lib/XML/LibXML/XPathContext.pm
+++ b/lib/XML/LibXML/XPathContext.pm
@@ -11,17 +11,16 @@ package XML::LibXML::XPathContext;
 
 use strict;
 use warnings;
-use vars qw($VERSION @ISA $USE_LIBXML_DATA_TYPES);
 
 use Carp;
 use XML::LibXML;
 use XML::LibXML::NodeList;
 
-$VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
+our $VERSION = "2.0210"; # VERSION TEMPLATE: DO NOT CHANGE
 
 # should LibXML XPath data types be used for simple objects
 # when passing parameters to extension functions (default: no)
-$USE_LIBXML_DATA_TYPES = 0;
+our $USE_LIBXML_DATA_TYPES = 0;
 
 sub CLONE_SKIP { 1 }
 

--- a/t/40reader_mem_error.t
+++ b/t/40reader_mem_error.t
@@ -30,9 +30,7 @@ use Test::More;
 
 use parent 'Exporter';
 
-use vars '@EXPORT_OK';
-
-@EXPORT_OK = (qw(is_xml_ordered));
+our @EXPORT_OK = (qw(is_xml_ordered));
 
 sub new
 {


### PR DESCRIPTION
The scripts that check or modify $VERSION seem to work fine with an `our $VERSION` declaration.