### PR TITLE
Update regression tests to handle Apple's local patching of libxml2

### DIFF
--- a/t/02parse.t
+++ b/t/02parse.t
@@ -884,7 +884,12 @@ EOXML
         eval {
            $doc2    = $parser->parse_string( $xmldoc );
         };
-        isnt($@, '', "error parsing $xmldoc");
+        # https://gitlab.gnome.org/GNOME/libxml2/-/commit/b717abdd
+        if (XML::LibXML::LIBXML_RUNTIME_VERSION() < 21300) {
+            isnt($@, '', "error parsing $xmldoc");
+        } else {
+            is( $doc2->documentElement()->firstChild()->nodeName(), "foo" );
+        }
 
         $parser->validation(1);
 

--- a/t/02parse.t
+++ b/t/02parse.t
@@ -14,7 +14,7 @@ use locale;
 
 POSIX::setlocale(LC_ALL, "C");
 
-use Test::More tests => 533;
+use Test::More tests => 531;
 use IO::File;
 
 use XML::LibXML::Common qw(:libxml);
@@ -25,7 +25,7 @@ use constant XML_DECL => "<?xml version=\"1.0\"?>\n";
 
 use Errno qw(ENOENT);
 
-# TEST*533
+# TEST*531
 
 ##
 # test values
@@ -773,15 +773,6 @@ EOXML
 
     my $newkid = $root->appendChild( $doc->createElement( "bar" ) );
     is( $newkid->line_number(), 0, "line number is 0");
-
-    $parser->line_numbers(0);
-    eval { $doc = $parser->parse_string( $goodxml ); };
-
-    $root = $doc->documentElement();
-    is( $root->line_number(), 0, "line number is 0");
-
-    @kids = $root->childNodes();
-    is( $kids[1]->line_number(), 0, "line number is 0");
 }
 
 SKIP: {

--- a/t/08findnodes.t
+++ b/t/08findnodes.t
@@ -123,7 +123,13 @@ my $docstring = q{
 my @ns = $root->findnodes('namespace::*');
 # TEST
 
-is(scalar(@ns), 2, ' TODO : Add test name' );
+# https://gitlab.gnome.org/GNOME/libxml2/-/commit/aca16fb3
+# fixed xmlCopyNamespace with XML namespace.
+if (XML::LibXML::LIBXML_RUNTIME_VERSION() < 21300) {
+    is(scalar(@ns), 2, ' TODO : Add test name' );
+} else {
+    is(scalar(@ns), 3, ' TODO : Add test name' );
+}
 
 # bad xpaths
 # TEST:$badxpath=4;

--- a/t/13dtd.t
+++ b/t/13dtd.t
@@ -99,11 +99,20 @@ ok($dtdstr, "DTD String read");
 
 ##
 # Tests for ticket 2021
-{
+eval {
     my $dtd = XML::LibXML::Dtd->new("","");
     # TEST
     ok (!defined($dtd), "XML::LibXML::Dtd not defined." );
-}
+    1;
+} or do {
+    # Apple has patched their libxml2 v2.9.13 so that xmlSAX2ResolveEntity
+    # throws an exception using xmlSAX2ErrMemory for the code path followed for
+    # a NULL URI. Since v2.9.yy upstream libxml2 has reworked the same code to
+    # better handle these problem cases, but it still returns NULL, not an
+    # exception. So this block really only applies on macOS with the system libs
+    is($@, "parser error : xmlSAX2ResolveEntity\n",
+       "XML::LibXML::Dtd throws an exception for a null URL");
+};
 
 {
     my $dtd = XML::LibXML::Dtd->new('', 'example/test.dtd');

--- a/t/16docnodes.t
+++ b/t/16docnodes.t
@@ -60,7 +60,12 @@ for my $time (0 .. 2) {
     $doc->setDocumentElement($node);
 
     # TEST
-    is( $node->serialize(), '<test contents="&#xE4;"/>', 'Node serialise works.' );
+    # libxml2 2.14 avoids unnecessary escaping of attribute values.
+    if (XML::LibXML::LIBXML_VERSION() >= 21400) {
+        is( $node->serialize(), "<test contents=\"\xE4\"/>", 'Node serialise works.' );
+    } else {
+        is( $node->serialize(), '<test contents="&#xE4;"/>', 'Node serialise works.' );
+    }
 
     $doc->setEncoding('utf-8');
     # Second output

--- a/t/19die_on_invalid_utf8_rt_58848.t
+++ b/t/19die_on_invalid_utf8_rt_58848.t
@@ -16,7 +16,7 @@ use XML::LibXML;
     my $err = $@;
 
     # TEST
-    like ("$err", qr{parser error : Input is not proper UTF-8},
+    like ("$err", qr{not proper UTF-8|Invalid bytes in character encoding},
         'Parser error.',
     );
 }

--- a/t/25relaxng.t
+++ b/t/25relaxng.t
@@ -132,7 +132,7 @@ print "# 6 check that no_network => 1 works\n";
 {
     my $rng = eval { XML::LibXML::RelaxNG->new( location => $netfile, no_network => 1 ) };
     # TEST
-    like( $@, qr{I/O error : Attempt to load network entity}, 'RNG from file location with external import and no_network => 1 throws an exception.' );
+    like( $@, qr{Attempt to load network entity}, 'RNG from file location with external import and no_network => 1 throws an exception.' );
     # TEST
     ok( !defined $rng, 'RNG from file location with external import and no_network => 1 is not loaded.' );
 }
@@ -152,7 +152,7 @@ print "# 6 check that no_network => 1 works\n";
 </grammar>
 EOF
     # TEST
-    like( $@, qr{I/O error : Attempt to load network entity}, 'RNG from buffer with external import and no_network => 1 throws an exception.' );
+    like( $@, qr{Attempt to load network entity}, 'RNG from buffer with external import and no_network => 1 throws an exception.' );
     # TEST
     ok( !defined $rng, 'RNG from buffer with external import and no_network => 1 is not loaded.' );
 }

--- a/t/26schema.t
+++ b/t/26schema.t
@@ -117,7 +117,7 @@ EOF
 {
     my $schema = eval { XML::LibXML::Schema->new( location => $netfile, no_network => 1 ) };
     # TEST
-    like( $@, qr{I/O error : Attempt to load network entity}, 'Schema from file location with external import and no_network => 1 throws an exception.' );
+    like( $@, qr{Attempt to load network entity}, 'Schema from file location with external import and no_network => 1 throws an exception.' );
     # TEST
     ok( !defined $schema, 'Schema from file location with external import and no_network => 1 is not loaded.' );
 }
@@ -129,7 +129,7 @@ EOF
 </xsd:schema>
 EOF
     # TEST
-    like( $@, qr{I/O error : Attempt to load network entity}, 'Schema from buffer with external import and no_network => 1 throws an exception.' );
+    like( $@, qr{Attempt to load network entity}, 'Schema from buffer with external import and no_network => 1 throws an exception.' );
     # TEST
     ok( !defined $schema, 'Schema from buffer with external import and no_network => 1 is not loaded.' );
 }

--- a/t/49_load_html.t
+++ b/t/49_load_html.t
@@ -52,7 +52,13 @@ use XML::LibXML;
 </div>
 EOS
 
-    {
+    SKIP: {
+        # libxml2 2.14 tokenizes HTML according to HTML5 where
+        # this isn't an error, see "13.2.5.73 Named character
+        # reference state".
+        skip("libxml2 version >= 21400", 1)
+            if XML::LibXML::LIBXML_VERSION >= 21400;
+
         my $buf = '';
         open my $fh, '>', \$buf;
         # redirect STDERR there

--- a/t/50devel.t
+++ b/t/50devel.t
@@ -1,5 +1,4 @@
 use Test::More;
-BEGIN { plan tests => 18 };
 
 use warnings;
 use strict;
@@ -16,6 +15,12 @@ $|=1;
 
   my $raw;
   my $mem_before = mem_used();
+
+  if($mem_before == 0) {
+    plan skip_all => "mem_used() returned 0 bytes, implying that memory debugging has been patched out of libxml2";
+  }
+  plan tests => 18;
+
   {
     my $node = $doc->createTextNode("Hello");
 

--- a/t/60error_prev_chain.t
+++ b/t/60error_prev_chain.t
@@ -16,13 +16,11 @@ use XML::LibXML;
 
 {
     my $parser = XML::LibXML->new();
-    $parser->validation(0);
-    $parser->load_ext_dtd(0);
 
     eval
     {
         local $^W = 0;
-        $parser->parse_file('example/JBR-ALLENtrees.htm');
+        $parser->parse_string('<doc>&ldquo;&nbsp;&rdquo;</doc>');
     };
 
     my $err = $@;
@@ -31,7 +29,7 @@ use XML::LibXML;
     if( $err && !ref($err) ) {
       plan skip_all => 'The local libxml library does not support errors as objects to $@';
     }
-    plan tests => 1;
+    plan tests => 2;
 
     while (defined($err) && $count < 200)
     {
@@ -44,6 +42,8 @@ use XML::LibXML;
 
     # TEST
     ok ((!$err), "Reached the end of the chain.");
+    # TEST
+    is ($count, 3, "Correct number of errors reported")
 }
 
 =head1 COPYRIGHT & LICENSE


### PR DESCRIPTION
This MR builds on the commits in #87 

Probably that MR should be merged, then this branch rebased on the merge commit

`t/13dtd.t` and `t/50devel.t` both fail on macOS because Apple have made local patches to their version of libxml2, which I believe to be v2.9.13. Apple have published their changes at https://github.com/apple-oss-distributions/libxml2

Apple's libxml2 throws an error in xmlSAX2ResolveEntity if URI is NULL. `t/13dtd.t` tests this case, but assumes the upstream behaviour of that C code returning `NULL` and hence `XML::LibXML::Dtd->new("","");` returning `undef`

Handle the Apple variant behaviour, rather than having the test script die. I'm fine with this Perl-space behaviour for the corner case being "implementation defined", rather than trying to work around the OS patching, given that the original bug report from 2004 was closed as

> NOT A BUG but a misunderstanding of the package.

https://rt.cpan.org/Public/Bug/Display.html?id=2021

well before `t/13dtd.t` was written.


The failure of `t/50devel.t` is messier. The tests that fail are the three instances of `cmp_ok(mem_used(), '>', mem_before);`

This turns out to be because `mem_used()` is now always reporting `0` - 0 bytes allocated. Upstream libxml2 vectors all allocation through functions in `xmlmemory.c`, and uses a static variable to record total allocation. Hence in `xmlMallocLoc` and similar functions about 20 lines in we have

```
    debugMemSize += size;
    debugMemBlocks++;
```

and then there is this function to read it

```
int
Xmlmemused(void) {
    int res;

    xmlMutexLock(xmlMemMutex);
    res = debugMemSize;
    xmlMutexUnlock(xmlMemMutex);
    return(res);
}
```

exposed to Perl space as `mem_used`

In their patched `xmlmemory.h` they have this:

```
+#if defined(LIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS)
+#define xmlMemMalloc(size) malloc(size)
+#define xmlMemRealloc(ptr, size) realloc(ptr, size)
+#define xmlMemFree(ptr) free(ptr)
+#define xmlMemoryStrdup(str) strdup(str)
+
+#define xmlMallocLoc(size, file, line) malloc(size)
+#define xmlReallocLoc(ptr, size, file, line) realloc((ptr), (size))
+#define xmlMallocAtomicLoc(size, file, line) malloc(size)
+#define xmlMemStrdupLoc(str, file, line) strdup(str)
+#endif
+
```

and in `xmlmemory.c` changes such as this:

```
@@ -161,6 +177,11 @@ xmlMallocBreakpoint(void) {
 void *
 xmlMallocLoc(size_t size, const char * file, int line)
 {
+#ifdef LIBXML_HAS_DEPRECATED_MEMORY_ALLOCATION_FUNCTIONS
+    if (linkedOnOrAfter2024EReleases())
+        return malloc(size);
+#endif
+
     MEMHDR *p;
     void *ret;

```

see https://github.com/apple-oss-distributions/libxml2/commit/5d4e3a3e53d290c9372767129ea6a09ffed97fae#diff-51ff3727803a305d66aca10db9fa81b1bdb2d5e3d201e99661df23df80f14af8 and https://github.com/apple-oss-distributions/libxml2/commit/5d4e3a3e53d290c9372767129ea6a09ffed97fae#diff-66a9bd352f0152960995cc8bfe359e35d7d03c0023705b26f84e919590d7a518

suggesting that there are both compile time and run time tests to determine whether to shortcut the wrapper.

The upshot is that

1. the wrapper is now ignored
2. debugMemSize is never updated
3. `mem_used` always returns 0

Hence I propose that we just skip the test if `xmlMemUsed` returns 0, as it's clearly inaccurate that there is **no** memory allocated, and it seems to be the easiest way to code a skip.