### PR TITLE
Revert "Remove memused tests"

### DIFF
--- a/t/50devel.t
+++ b/t/50devel.t
@@ -10,9 +10,7 @@ use XML::LibXML::Devel qw(:all);
 $|=1;
 
 # Base line
-SKIP: {
-  skip("memory debugging was removed in 2.16.0", 18)
-    if XML::LibXML::LIBXML_VERSION >= 21600;
+{
   my $doc = XML::LibXML::Document->new();
 
   my $raw;


### PR DESCRIPTION
This reverts commit 95c039ac122d085ed93ae7f520c92804faddc202 which clashes with e1f7d5f2a. The latter is a better fix for the issue.