### PR TITLE
Work around some libxml2 deprecations

### DIFF
--- a/Devel.xs
+++ b/Devel.xs
@@ -39,18 +39,12 @@
 #endif
 
 #ifdef HAVE_LIBXML_MEMORY_DEBUG
-static void *	xmlMemMallocAtomic(size_t size)
-{
-    return xmlMallocAtomicLoc(size, "none", 0);
-}
-
 static int debug_memory()
 {
-    return xmlGcMemSetup( xmlMemFree,
-                          xmlMemMalloc,
-                          xmlMemMallocAtomic,
-                          xmlMemRealloc,
-                          xmlMemStrdup);
+    return xmlMemSetup(xmlMemFree,
+                       xmlMemMalloc,
+                       xmlMemRealloc,
+                       xmlMemStrdup);
 }
 #endif
 

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -3150,7 +3150,7 @@ createDocument( CLASS, version="1.0", encoding=NULL )
         PERL_UNUSED_VAR(ix);
         doc = xmlNewDoc((const xmlChar*)version);
         if (encoding && *encoding != 0) {
-            doc->encoding = (const xmlChar*)xmlStrdup((const xmlChar*)encoding);
+            doc->encoding = xmlStrdup((const xmlChar*)encoding);
         }
         RETVAL = PmmNodeToSv(INT2PTR(xmlNodePtr,doc),NULL);
     OUTPUT:

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -9698,7 +9698,7 @@ encodeToUTF8( encoding, string )
                     in    = xmlBufferCreateStatic((void*)realstring, len );
                     out   = xmlBufferCreate();
                     if ( xmlCharEncInFunc( coder, out, in ) >= 0 ) {
-                        tstr = xmlStrdup( out->content );
+                        tstr = xmlBufferDetach( out );
                     }
 
                     xmlBufferFree( in );
@@ -9788,7 +9788,7 @@ decodeFromUTF8( encoding, string )
                     xmlBufferCCat( in, (char*) realstring );
                     if ( xmlCharEncOutFunc( coder, out, in ) >= 0 ) {
                         len  = xmlBufferLength( out );
-                        tstr = xmlCharStrndup( (char*) xmlBufferContent( out ), len );
+                        tstr = xmlBufferDetach( out );
                     }
 
                     xmlBufferFree( in );

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -1731,7 +1731,7 @@ _parse_string(self, string, dir = &PL_sv_undef)
             ctxt->directory = NULL;
             well_formed = ctxt->wellFormed;
             valid = ctxt->valid;
-            validate = ctxt->validate;
+            validate = ctxt->options & XML_PARSE_DTDVALID ? 1 : 0;
             real_doc = ctxt->myDoc;
             ctxt->myDoc = NULL;
             xmlFreeParserCtxt(ctxt);
@@ -1884,7 +1884,7 @@ _parse_fh(self, fh, dir = &PL_sv_undef)
             ctxt->directory = NULL;
             well_formed = ctxt->wellFormed;
             valid = ctxt->valid;
-            validate = ctxt->validate;
+            validate = ctxt->options & XML_PARSE_DTDVALID ? 1 : 0;
             real_doc = ctxt->myDoc;
             ctxt->myDoc = NULL;
             xmlFreeParserCtxt(ctxt);
@@ -2033,7 +2033,7 @@ _parse_file(self, filename_sv)
 
             well_formed = ctxt->wellFormed;
             valid = ctxt->valid;
-            validate = ctxt->validate;
+            validate = ctxt->options & XML_PARSE_DTDVALID ? 1 : 0;
             real_doc = ctxt->myDoc;
             ctxt->myDoc = NULL;
             xmlFreeParserCtxt(ctxt);

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -910,29 +910,6 @@ LibXML_load_external_entity(
  * Helper functions
  * **************************************************************** */
 
-/* Set xmlKeepBlanksDefault before context creation so the new context
-   inherits the correct value.  Must be called before xmlCreate*ParserCtxt.
-   See https://github.com/shlomif/perl-XML-LibXML/issues/88 */
-void
-LibXML_init_global_state( SV * self ) {
-    HV* real_obj;
-    SV** item;
-    int parserOptions = XML_PARSE_NODICT;
-
-    if ( self != NULL ) {
-        real_obj = (HV *)SvRV(self);
-        item = hv_fetch( real_obj, "XML_LIBXML_PARSER_OPTIONS", 25, 0 );
-        if (item != NULL && SvOK(*item)) parserOptions = sv_2iv(*item);
-
-        if (parserOptions & XML_PARSE_NOBLANKS) {
-            xmlKeepBlanksDefault(0);
-        }
-        else {
-            xmlKeepBlanksDefault(1);
-        }
-    }
-}
-
 HV*
 LibXML_init_parser( SV * self, xmlParserCtxtPtr ctxt ) {
     /* we fetch all switches and callbacks from the hash */
@@ -969,26 +946,6 @@ LibXML_init_parser( SV * self, xmlParserCtxtPtr ctxt ) {
             parserOptions &= ~(XML_PARSE_DTDVALID | XML_PARSE_DTDATTR | XML_PARSE_NOENT );
         }
         if (ctxt) xmlCtxtUseOptions(ctxt, parserOptions ); /* Note: sets ctxt->linenumbers = 1 */
-
-        /*
-         * Without this if/else conditional, NOBLANKS has no effect.
-         *
-         * For more information, see:
-         *
-         * https://rt.cpan.org/Ticket/Display.html?id=76696
-         *
-         * */
-        if (parserOptions & XML_PARSE_NOBLANKS) {
-            xmlKeepBlanksDefault(0);
-        }
-        else {
-            xmlKeepBlanksDefault(1);
-        }
-        /* xmlKeepBlanksDefault() only affects future contexts.
-           The current context inherited the old global value at creation time,
-           and xmlCtxtUseOptions() does not reset keepBlanks when NOBLANKS
-           is absent.  Set it explicitly to match the requested options. */
-        if (ctxt) ctxt->keepBlanks = (parserOptions & XML_PARSE_NOBLANKS) ? 0 : 1;
 
         item =  hv_fetch( real_obj, "XML_LIBXML_LINENUMBERS", 22, 0 );
         if ( item != NULL && SvTRUE(*item) ) {
@@ -1749,7 +1706,6 @@ _parse_string(self, string, dir = &PL_sv_undef)
         RETVAL = &PL_sv_undef;
         INIT_ERROR_HANDLER;
         {
-            LibXML_init_global_state(self);
             xmlParserCtxtPtr ctxt = xmlCreateMemoryParserCtxt(ptr, len);
             if (ctxt == NULL) {
 	        CLEANUP_ERROR_HANDLER;
@@ -1839,7 +1795,6 @@ _parse_sax_string(self, string)
         INIT_ERROR_HANDLER;
 
         {
-            LibXML_init_global_state(self);
             xmlParserCtxtPtr ctxt = xmlCreateMemoryParserCtxt((const char*)ptr, len);
             if (ctxt == NULL) {
                 CLEANUP_ERROR_HANDLER;
@@ -1904,7 +1859,6 @@ _parse_fh(self, fh, dir = &PL_sv_undef)
                 croak( "Empty Stream\n" );
             }
 
-            LibXML_init_global_state(self);
             ctxt = xmlCreatePushParserCtxt(NULL, NULL, buffer, read_length, NULL);
             if (ctxt == NULL) {
                 CLEANUP_ERROR_HANDLER;
@@ -2003,7 +1957,6 @@ _parse_sax_fh(self, fh, dir = &PL_sv_undef)
                 croak( "Empty Stream\n" );
             }
 
-            LibXML_init_global_state(self);
             sax = PSaxGetHandler();
             ctxt = xmlCreatePushParserCtxt(sax, NULL, buffer, read_length, NULL);
             if (ctxt == NULL) {
@@ -2069,7 +2022,6 @@ _parse_file(self, filename_sv)
         INIT_ERROR_HANDLER;
 
         {
-            LibXML_init_global_state(self);
             xmlParserCtxtPtr ctxt = xmlCreateFileParserCtxt(filename);
             if (ctxt == NULL) {
                 CLEANUP_ERROR_HANDLER;
@@ -2134,7 +2086,6 @@ _parse_sax_file(self, filename_sv)
         INIT_ERROR_HANDLER;
 
         {
-            LibXML_init_global_state(self);
             xmlParserCtxtPtr ctxt = xmlCreateFileParserCtxt(filename);
             if (ctxt == NULL) {
                 CLEANUP_ERROR_HANDLER;
@@ -2399,6 +2350,9 @@ _parse_xml_chunk(self, svchunk, enc = &PL_sv_undef)
         int recover = 0;
         xmlChar * chunk;
         xmlNodePtr rv = NULL;
+        SV** item;
+        int parserOptions = 0;
+        int oldKeepBlanks;
         PREINIT_SAVED_ERROR
     INIT:
         if (SvPOK(enc)) {
@@ -2417,7 +2371,29 @@ _parse_xml_chunk(self, svchunk, enc = &PL_sv_undef)
         if ( chunk != NULL ) {
             recover = LibXML_get_recover(real_obj);
 
+            item = hv_fetch( real_obj, "XML_LIBXML_PARSER_OPTIONS", 25, 0 );
+            if (item != NULL && SvOK(*item)) parserOptions = sv_2iv(*item);
+
+            /*
+             * Without this if/else conditional, NOBLANKS has no effect.
+             *
+             * For more information, see:
+             *
+             * https://rt.cpan.org/Ticket/Display.html?id=76696
+             *
+             * This hack should be removed once libxml2 offers a better
+             * API. See https://gitlab.gnome.org/GNOME/libxml2/-/issues/727
+             */
+            if (parserOptions & XML_PARSE_NOBLANKS) {
+                oldKeepBlanks = xmlKeepBlanksDefault(0);
+            }
+            else {
+                oldKeepBlanks = xmlKeepBlanksDefault(1);
+            }
+
             rv = domReadWellBalancedString( NULL, chunk, recover );
+
+            xmlKeepBlanksDefault(oldKeepBlanks);
 
             if ( rv != NULL ) {
                 xmlNodePtr fragment= NULL;
@@ -2473,6 +2449,9 @@ _parse_sax_xml_chunk(self, svchunk, enc = &PL_sv_undef)
         int retCode              = -1;
         xmlNodePtr nodes         = NULL;
         xmlSAXHandlerPtr handler = NULL;
+        SV** item;
+        int parserOptions = 0;
+        int oldKeepBlanks;
         PREINIT_SAVED_ERROR
     INIT:
         if (SvPOK(enc)) {
@@ -2491,7 +2470,6 @@ _parse_sax_xml_chunk(self, svchunk, enc = &PL_sv_undef)
         chunk = Sv2C(svchunk, (const xmlChar*)encoding);
 
         if ( chunk != NULL ) {
-            LibXML_init_global_state(self);
             xmlParserCtxtPtr ctxt = xmlCreateMemoryParserCtxt((const char*)ptr, len);
             if (ctxt == NULL) {
                 CLEANUP_ERROR_HANDLER;
@@ -2505,12 +2483,34 @@ _parse_sax_xml_chunk(self, svchunk, enc = &PL_sv_undef)
             PmmSAXInitContext( ctxt, self, saved_error );
             handler = PSaxGetHandler();
 
+            item = hv_fetch( real_obj, "XML_LIBXML_PARSER_OPTIONS", 25, 0 );
+            if (item != NULL && SvOK(*item)) parserOptions = sv_2iv(*item);
+
+            /*
+             * Without this if/else conditional, NOBLANKS has no effect.
+             *
+             * For more information, see:
+             *
+             * https://rt.cpan.org/Ticket/Display.html?id=76696
+             *
+             * This hack should be removed once libxml2 offers a better
+             * API. See https://gitlab.gnome.org/GNOME/libxml2/-/issues/727
+             */
+            if (parserOptions & XML_PARSE_NOBLANKS) {
+                oldKeepBlanks = xmlKeepBlanksDefault(0);
+            }
+            else {
+                oldKeepBlanks = xmlKeepBlanksDefault(1);
+            }
+
             retCode = xmlParseBalancedChunkMemory( NULL,
                                                    handler,
                                                    ctxt,
                                                    0,
                                                    chunk,
                                                    &nodes );
+
+            xmlKeepBlanksDefault(oldKeepBlanks);
 
             xmlFree( handler );
             PmmSAXCloseContext(ctxt);
@@ -2579,7 +2579,6 @@ _start_push(self, with_sax=0)
         INIT_ERROR_HANDLER;
 
         /* create empty context */
-        LibXML_init_global_state(self);
         ctxt = xmlCreatePushParserCtxt( NULL, NULL, NULL, 0, NULL );
         real_obj = LibXML_init_parser(self,ctxt);
         recover = LibXML_get_recover(real_obj);

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -945,15 +945,7 @@ LibXML_init_parser( SV * self, xmlParserCtxtPtr ctxt ) {
         if ((parserOptions & XML_PARSE_DTDLOAD) == 0) {
             parserOptions &= ~(XML_PARSE_DTDVALID | XML_PARSE_DTDATTR | XML_PARSE_NOENT );
         }
-        if (ctxt) xmlCtxtUseOptions(ctxt, parserOptions ); /* Note: sets ctxt->linenumbers = 1 */
-
-        item =  hv_fetch( real_obj, "XML_LIBXML_LINENUMBERS", 22, 0 );
-        if ( item != NULL && SvTRUE(*item) ) {
-            if (ctxt) ctxt->linenumbers = 1;
-        }
-        else {
-            if (ctxt) ctxt->linenumbers = 0;
-        }
+        if (ctxt) xmlCtxtUseOptions(ctxt, parserOptions);
 
        /* If a user installed a process-global loader via externalEntityLoader(),
         * leave it alone -- they're the policy authority. See CLAUDE.md

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -9452,10 +9452,6 @@ context_and_column( self )
 	}
        if (ctxt == NULL) XSRETURN_EMPTY;
        input = ctxt->input;
-       if ((input != NULL) && (input->filename == NULL) &&
-            (ctxt->inputNr > 1)) {
-            input = ctxt->inputTab[ctxt->inputNr - 2];
-        }
         if (input == NULL) XSRETURN_EMPTY;
 	cur = input->cur;
 	base = input->base;

--- a/LibXML.xs
+++ b/LibXML.xs
@@ -200,7 +200,7 @@ SV* PROXY_NODE_REGISTRY_MUTEX = NULL;
 #endif  /* WITH_SERRORS */
 
 #ifdef WITH_SERRORS
-void
+static void
 LibXML_struct_error_callback(SV * saved_error, SV * libErr )
 {
 
@@ -240,7 +240,7 @@ LibXML_struct_error_callback(SV * saved_error, SV * libErr )
     LEAVE;
 }
 
-void
+static void
 LibXML_struct_error_handler(SV * saved_error, xmlErrorPtr error )
 {
     const char * CLASS = "XML::LibXML::LibError";
@@ -252,7 +252,7 @@ LibXML_struct_error_handler(SV * saved_error, xmlErrorPtr error )
 }
 
 
-void
+static void
 LibXML_flat_handler(SV * saved_error, const char * msg, ...)
 {
     SV* sv;
@@ -271,7 +271,7 @@ LibXML_flat_handler(SV * saved_error, const char * msg, ...)
 
 /* If threads-support is working correctly in libxml2 then
  * this method will be called with the correct thread-context */
-void
+static void
 LibXML_error_handler_ctx(void * ctxt, const char * msg, ...)
 {
 	va_list args;
@@ -448,7 +448,7 @@ LibXML_reader_error_handler(void * ctxt,
 }
 #endif /* !defined WITH_SERRORS */
 
-SV *
+static SV *
 LibXML_get_reader_error_data(xmlTextReaderPtr reader)
 {
   SV * saved_error = NULL;
@@ -496,7 +496,7 @@ LibXML_NodeToSv(HV * real_obj, xmlNodePtr real_doc)
  * IO callbacks
  * **************************************************************** */
 
-int
+static int
 LibXML_read_perl (SV * ioref, char * buffer, int len)
 {
     dTHX;
@@ -570,14 +570,14 @@ LibXML_read_perl (SV * ioref, char * buffer, int len)
 }
 
 /* used only by Reader */
-int
+static int
 LibXML_close_perl (SV * ioref)
 {
   SvREFCNT_dec(ioref);
   return 0;
 }
 
-int
+static int
 LibXML_input_match(char const * filename)
 {
     int results;
@@ -625,7 +625,7 @@ LibXML_input_match(char const * filename)
     return results;
 }
 
-void *
+static void *
 LibXML_input_open(char const * filename)
 {
     SV * results;
@@ -667,7 +667,7 @@ LibXML_input_open(char const * filename)
     return (void *)results;
 }
 
-int
+static int
 LibXML_input_read(void * context, char * buffer, int len)
 {
     STRLEN res_len;
@@ -733,7 +733,7 @@ LibXML_input_read(void * context, char * buffer, int len)
     return res_len;
 }
 
-int
+static int
 LibXML_input_close(void * context)
 {
     SV * ctxt;
@@ -767,7 +767,7 @@ LibXML_input_close(void * context)
     return 0;
 }
 
-int
+static int
 LibXML_output_write_handler(void * ioref, char * buffer, int len)
 {
     if ( buffer != NULL && len > 0) {
@@ -800,7 +800,7 @@ LibXML_output_write_handler(void * ioref, char * buffer, int len)
     return len;
 }
 
-int
+static int
 LibXML_output_close_handler( void * handler )
 {
     return 1;
@@ -810,7 +810,7 @@ LibXML_output_close_handler( void * handler )
  * "ext_ent_handler" or process-global externalEntityLoader()). DO NOT add
  * URL filtering or no_network checks here -- the user's callback is the
  * policy authority. See CLAUDE.md "Entity loaders" and GH #168/#133/#143. */
-xmlParserInputPtr
+static xmlParserInputPtr
 LibXML_load_external_entity(
         const char * URL,
         const char * ID,
@@ -910,7 +910,7 @@ LibXML_load_external_entity(
  * Helper functions
  * **************************************************************** */
 
-HV*
+static HV*
 LibXML_init_parser( SV * self, xmlParserCtxtPtr ctxt ) {
     /* we fetch all switches and callbacks from the hash */
     HV* real_obj = NULL;
@@ -972,7 +972,7 @@ LibXML_init_parser( SV * self, xmlParserCtxtPtr ctxt ) {
     return real_obj;
 }
 
-void
+static void
 LibXML_cleanup_parser() {
 #ifndef WITH_SERRORS
     xmlGetWarningsDefaultValue = 0;
@@ -984,7 +984,7 @@ LibXML_cleanup_parser() {
     }
 }
 
-int
+static int
 LibXML_test_node_name( xmlChar * name )
 {
     if ( name == NULL || *name == 0 ) {

--- a/MANIFEST
+++ b/MANIFEST
@@ -199,6 +199,7 @@ t/91unique_key.t
 t/cpan-changes.t
 t/data/callbacks_returning_undef.xml
 t/data/chinese.xml
+t/data/invalid-entity.xml
 t/lib/Collector.pm
 t/lib/Counter.pm
 t/lib/Stacker.pm

--- a/dom.c
+++ b/dom.c
@@ -929,15 +929,18 @@ domGetNodeValue( xmlNodePtr n ) {
                 /* ok then toString in this case ... */
                 while (cnode) {
                     xmlBufferPtr buffer = xmlBufferCreate();
+                    xmlChar *content;
                     /* buffer = xmlBufferCreate(); */
                     xmlNodeDump( buffer, n->doc, cnode, 0, 0 );
-                    if ( buffer->content != NULL ) {
+                    content = xmlBufferDetach(buffer);
+                    if ( content != NULL ) {
                         xs_warn( "add item" );
                         if ( retval != NULL ) {
-                            retval = xmlStrcat( retval, buffer->content );
+                            retval = xmlStrcat( retval, content );
+                            xmlFree(content);
                         }
                         else {
-                            retval = xmlStrdup( buffer->content );
+                            retval = content;
                         }
                     }
                     xmlBufferFree( buffer );

--- a/perl-libxml-mm.c
+++ b/perl-libxml-mm.c
@@ -989,7 +989,7 @@ PmmFastEncodeString( int charset,
         in    = xmlBufferCreateStatic((void*)string, len);
         out   = xmlBufferCreate();
         if ( xmlCharEncInFunc( coder, out, in ) >= 0 ) {
-            retval = xmlStrdup( out->content );
+            retval = xmlBufferDetach( out );
             /* warn( "encoded string is %s" , retval); */
         }
         else {
@@ -1042,7 +1042,7 @@ PmmFastDecodeString( int charset,
         out = xmlBufferCreate();
         if ( xmlCharEncOutFunc( coder, out, in ) >= 0 ) {
           *len = xmlBufferLength(out);
-	  retval = xmlStrndup(xmlBufferContent(out), *len);
+	  retval = xmlBufferDetach(out);
         }
         else {
             /* xs_warn("PmmFastEncodeString: decoding error\n"); */

--- a/t/02parse.t
+++ b/t/02parse.t
@@ -14,7 +14,7 @@ use locale;
 
 POSIX::setlocale(LC_ALL, "C");
 
-use Test::More tests => 531;
+use Test::More tests => 532;
 use IO::File;
 
 use XML::LibXML::Common qw(:libxml);
@@ -955,6 +955,16 @@ EOXML
     like( $@, qr/Read more bytes than requested/,
           'UTF-8 encoding layer throws exception' );
     close($fh);
+}
+
+{
+    my $parser = XML::LibXML->new();
+
+    eval {
+        $parser->parse_file('t/data/invalid-entity.xml');
+    };
+    like( $@, qr|<a xmlns:xml='foo'/>|,
+          'error context is inside entity' );
 }
 
 sub tsub {

--- a/t/data/invalid-entity.xml
+++ b/t/data/invalid-entity.xml
@@ -1,0 +1,4 @@
+<!DOCTYPE doc [
+  <!ENTITY ent "<a xmlns:xml='foo'/>">
+]>
+<doc>&ent;</doc>


### PR DESCRIPTION
This is a first batch of fixes to stop using deprecated libxml2 functions and struct members, or at least prepare for better fixes. There's one unrelated commit that makes helper functions static.